### PR TITLE
#158559988 Fetch and show categories under interests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version: 2
 jobs:
   build:
     docker:
-       - image: circleci/ruby:2.5.1-node-browsers
+       - image: circleci/ruby:2.4.1-node-browsers
        - image: circleci/mongo:3.2-ram
 
     working_directory: ~/repo

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,5 @@
 source 'https://rubygems.org'
+ruby '2.4.1'
 
 gem 'bcrypt'
 gem 'haml'
@@ -8,7 +9,6 @@ gem 'rake'
 gem 'shotgun'
 gem 'sinatra'
 gem 'sinatra-partial'
-
 
 group :test do
   gem 'database_cleaner'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -21,7 +21,7 @@ GEM
       concurrent-ruby (~> 1.0)
     method_source (0.9.0)
     minitest (5.11.3)
-    mongo (2.6.0)
+    mongo (2.6.1)
       bson (>= 4.3.0, < 5.0.0)
     mongoid (7.0.1)
       activemodel (>= 5.1, < 6.0.0)
@@ -82,6 +82,9 @@ DEPENDENCIES
   shotgun
   sinatra
   sinatra-partial
+
+RUBY VERSION
+   ruby 2.4.1p111
 
 BUNDLED WITH
    1.16.2

--- a/Rakefile
+++ b/Rakefile
@@ -1,7 +1,5 @@
 require 'mongoid'
 require 'logger'
-require 'rspec/core'
-require 'rspec/core/rake_task'
 
 logger = Logger.new($stdout)
 ROOT = File.expand_path('.', File.dirname(__FILE__))
@@ -62,11 +60,5 @@ namespace :db do
       require seeder
       logger.info "Seeder created for #{seeder}"
     end
-  end
-end
-
-namespace :rspec do
-  task :run_tests do
-    RSpec::Core::RakeTask.new(:spec)
   end
 end

--- a/app/controllers/profile_controller.rb
+++ b/app/controllers/profile_controller.rb
@@ -1,5 +1,6 @@
 require_relative './application_controller'
 require_relative '../models/user'
+require_relative '../models/category'
 
 # Handles user profile.
 class ProfileController < ApplicationController
@@ -8,6 +9,7 @@ class ProfileController < ApplicationController
 
     @css_link = 'style.css'
     @user = User.find_by(_id: session[:user_id])
+    @categories = Category.all
     haml :profile
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -10,8 +10,8 @@ module Sinatra
       params
     end
 
-    def roles
-      roles = ['admin', 'user']
+    def user_roles
+      %w[admin user]
     end
   end
 

--- a/app/views/_sidebar.haml
+++ b/app/views/_sidebar.haml
@@ -13,7 +13,7 @@
         %li{:class => "menu-tree"}
           %i{:class => "fas fa-cogs"}
           %a{:href => ""} Settings
-        - if @user.role == roles[0]
+        - if @user.role == user_roles[0]
           %li{:class => "menu-tree"}
             %i{:class => "fas fa-bars"}
             %a{:href => "/category"} Categories

--- a/app/views/profile.haml
+++ b/app/views/profile.haml
@@ -47,10 +47,10 @@
               %label{:for => "interests", :class =>"col-sm-2 col-form-label"} Interests
               %div{:class => "col-sm-7"}
                 %select{:class => "form-control", :multiple => true, :required => true, :name => "user[interests][]"}
-                  %option Technology
-                  %option Environment
-                  %option Science
-                  %option Business
+                  - @categories.each do |value|
+                    %option{:title => value.description} #{value.name}
+                %small #{@user.interests}
+
             %button{:type => "submit", :class => "submit-btn"} Save
 
         %div{:id => "password-tab", :class => "tab-pane fade"}

--- a/config/mongoid.yml
+++ b/config/mongoid.yml
@@ -15,5 +15,9 @@ development:
 production:
   clients:
     default:
-      database: micro_learning_db
-      uri: <%= ENV['MONGODB_URI'] %>
+      database: <%= ENV['DATABASE_NAME'] %>
+      hosts:
+        - ds239911.mlab.com:39911
+      options:
+        user: <%= ENV['DATABASE_USER'] %>
+        password: <%= ENV['DATABASE_PASSWORD'] %>


### PR DESCRIPTION
#### What does this PR do?
Fetches and shows categories that the user can pick as interests.

#### Description of the task to be completed?
Currently, when an administrator creates a category a normal user cannot select it. This PR adds a feature where a user can select different categories and take them on as interests. With this, a user can add and remove interests.

#### How should this be manually tested?
By navigating to the profile page.
#### What are the relevant pivotal tracker stories?
(158559988)[https://www.pivotaltracker.com/story/show/158559988]
#### Screenshots
<img width="1362" alt="screen shot 2018-07-18 at 17 52 40" src="https://user-images.githubusercontent.com/11385771/42889556-6a4ceeaa-8ab3-11e8-85fc-911b93482839.png">
